### PR TITLE
Reset the hashbang prefix to ''

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -109,6 +109,10 @@ porybox.config(['markedProvider', markedProvider => {
   markedProvider.setOptions({gfm: true, sanitize: true});
 }]);
 
+porybox.config(['$locationProvider', function($locationProvider) {
+  $locationProvider.hashPrefix('');
+}]);
+
 porybox.service('io', function () {
   const socket = require('socket.io-client');
   const io = require('sails.io.js')(socket);


### PR DESCRIPTION
Fixes #646

They  changed the default from '' to '!'. Easiest way to solve all the problems is just set it back to default.