### PR TITLE
Fix broken pre-assigned bindings

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -113,6 +113,10 @@ porybox.config(['$locationProvider', function($locationProvider) {
   $locationProvider.hashPrefix('');
 }]);
 
+porybox.config(['$compileProvider', function($compileProvider) {
+  $compileProvider.preAssignBindingsEnabled(true);
+}]);
+
 porybox.service('io', function () {
   const socket = require('socket.io-client');
   const io = require('sails.io.js')(socket);


### PR DESCRIPTION
We should fix this properly at some point, but for now, we are fine just to change the config. It will be removed at some point in angular, but I don't think we want to focus on that right now.

Details: https://docs.angularjs.org/guide/migration#commit-bcd0d4