### PR TITLE
Fix bouncing upload toast with large uploads (fixes #737)

### DIFF
--- a/client/add/add.spec.js
+++ b/client/add/add.spec.js
@@ -130,7 +130,7 @@ describe('AddCtrl', () => {
         expect(positionSpy.calledTwice).to.equal(true);
         expect(hideSpy.calledTwice).to.equal(true);
         expect(textContentSpy.calledTwice).to.equal(true);
-        expect(textContentSpy.args[0][0]).to.equal('Uploading Pokémon');
+        expect(textContentSpy.args[0][0]).to.equal('Uploading Pokémon...');
         expect(showSpy.calledTwice).to.equal(true);
       });
     });

--- a/client/test/mdtoast.js
+++ b/client/test/mdtoast.js
@@ -29,6 +29,8 @@ const toast = class toast{
   }
 
   hide () {}
+
+  updateTextContent () {}
 };
 
 module.exports = toast;


### PR DESCRIPTION
This adds a progress meter for uploads rather than having the "Uploading" toast bounce up and down repeatedly.

![](https://i.gyazo.com/0ef7940c5554e9b7ea4a218aadd3586c.gif)