### PR TITLE
Remove hardcoded upper bound in save file parsing

### DIFF
--- a/client/add/parseSaveFile.js
+++ b/client/add/parseSaveFile.js
@@ -124,7 +124,7 @@ class Pkx {
   static verifyChk(pkx) {
     let chk = 0;
     const pkx16 = new Uint16Array(pkx.buffer, pkx.byteOffset, pkx.byteLength >> 1);
-    if (pkx16[4] > 750 || pkx16[0x48] !== 0) return false;
+    if (pkx16[0x48]) return false;
     for (let i = 4; i < 116; i++) {
       chk += pkx16[i];
     }


### PR DESCRIPTION
As a result of this, nothing with a dex number of greater than 750 could be uploaded.