### PR TITLE
Update the _boxVisibility when moving a pokemon

### DIFF
--- a/api/controllers/PokemonController.js
+++ b/api/controllers/PokemonController.js
@@ -242,7 +242,7 @@ module.exports = _.mapValues({
     pokemon.box = newBox.id;
     const promises = [
       BoxOrdering.addPkmnIdsToBox(newBox.id, [pokemon.id], adjIndex),
-      Pokemon.update({id: pokemon.id}, {box: newBox.id})
+      Pokemon.update({id: pokemon.id}, {box: newBox.id, _boxVisibility: newBox.visibility})
     ];
     await Promise.all(promises);
     return res.ok();


### PR DESCRIPTION
As a potential security issue, this has already been cherry-picked onto production.