### PR TITLE
Updated documentation for 3DS update 11.4

### DIFF
--- a/client/static/extracting-pokemon-files.html
+++ b/client/static/extracting-pokemon-files.html
@@ -46,8 +46,8 @@
         <td>2</td>
         <td><a href="/#/how-to-pk6-2-homebrew">Homebrew</a></td>
         <td>Digital/retail</td>
-        <td>SD card reader, Nintendo 3DS Sound, Cubic Ninja (optional), Zelda OoT3D (optional), Freakyforms Deluxe (optional)</td>
-        <td>=&lt;11.3.0</td>
+        <td>SD card reader, Nintendo 3DS Sound (if on =&lt;11.3.0), Swapdoodle (if on N3DS 11.4.0), Cubic Ninja (optional), Freakyforms Deluxe (optional)</td>
+        <td>=&lt;11.3.0 (O3DS),<br />=&lt;11.4.0 (N3DS)</td>
         <td>Required hardware depends on firmware version</td>
       </tr>
       <tr>
@@ -118,8 +118,8 @@
         <td>2</td>
         <td><a href="/#/how-to-pk7-2-homebrew">Homebrew</a></td>
         <td>Digital/retail</td>
-        <td>SD card reader, Nintendo 3DS Sound, Cubic Ninja (optional), Zelda OoT3D (optional), Freakyforms Deluxe (optional)</td>
-        <td>=&lt;11.3.0</td>
+        <td>SD card reader, Nintendo 3DS Sound (if on =&lt;11.3.0), Swapdoodle (if on N3DS 11.4.0), Cubic Ninja (optional), Freakyforms Deluxe (optional)</td>
+        <td>=&lt;11.3.0 (O3DS),<br />=&lt;11.4.0 (N3DS)</td>
         <td>Required hardware depends on firmware version</td>
       </tr>
       <tr>
@@ -135,7 +135,7 @@
         <td><a href="/#/how-to-pk7-4-tea">TEA checking with KeySAVe</a></td>
         <td>Digital/retail</td>
         <td>CFW, NTR CFW</td>
-        <td>=&lt;11.2.0</td>
+        <td>=&lt;11.3.0</td>
         <td>Required hardware depends on firmware version</td>
       </tr>
   </div>

--- a/client/static/how-to-pk6-2-homebrew.html
+++ b/client/static/how-to-pk6-2-homebrew.html
@@ -10,11 +10,30 @@
     <p>Requirements for current exploits allow for homebrew on most firmware versions. You will need:</p>
 
     <ul>
-    <li>A console with a firmware version from 9.0.0 through 11.3.0.</li>
+    <li>A console with a firmware version from 9.0.0 through 11.3.0 (or 11.4.0 if using a New 3DS).</li>
     <li>For other versions, refer to <a class="md-body-2" href="https://3ds.guide/" target="_blank" rel="noreferrer">Plailect’s guide</a> for possible solutions.</li>
     </ul>
 
-    <p>Use the <a class="md-body-2" href="https://3ds.guide/homebrew-launcher-(soundhax)" target="_blank" rel="noreferrer">SoundHax section of Plailect’s guide</a> to install homebrew. Once your have access to the Homebrew Launcher using SoundHax, you can move on to the next step of this guide. Alternatively, if you are on 11.2.0 or lower and wish to install CFW to help ensure you retain homebrew access after future updates, proceed with the remaining sections of Plailect's guide and return here afterward.</p>
+    <p>If you are on 11.3.0 or lower, use the <a class="md-body-2" href="https://3ds.guide/homebrew-launcher-(soundhax)" target="_blank" rel="noreferrer">SoundHax section of Plailect’s guide</a> to install homebrew. Once your have access to the Homebrew Launcher using SoundHax, you can move on to the next step of this guide. Alternatively, if you wish to install CFW to help ensure you retain homebrew access after future updates, proceed with the remaining sections of Plailect's guide and return here afterward.</p>
+	
+	<p>If you are using a New 3DS on 11.4.0, you will not be able to install CFW, but you may be able to gain homebrew access by using one of the following exploits if you have the required game:</p>
+	
+	<table>
+		<tr>
+			<th>Exploit</th><th>Required Game</th>
+		</tr>
+		<tr>
+			<td><a class="md-body-2" href="https://mrnbayoh.github.io/doodlebomb/" target="_blank" rel="noreferrer">doodlebomb</a></td><td>Swapdoodle (free on Nintendo eShop)</td>
+		</tr>
+		<tr>
+			<td><a class="md-body-2" href="https://smealum.github.io/ninjhax2/" target="_blank" rel="noreferrer">ninjhax</a></td><td>Cubic Ninja</td>
+		</tr>
+		<tr>
+			<td><a class="md-body-2" href="https://plutooo.github.io/freakyhax/" target="_blank" rel="noreferrer">freakyhax</a></td><td>Freakyforms Deluxe</td>
+		</tr>
+	</table>
+	
+	<p>As of this writing on 2017/04/19, homebrew is not useable on old 3DS consoles running 11.4.0.</p>
 
     <h2 class="md-headline">JKSM</h2>
 

--- a/client/static/how-to-pk7-2-homebrew.html
+++ b/client/static/how-to-pk7-2-homebrew.html
@@ -10,11 +10,30 @@
     <p>Requirements for current exploits allow for homebrew on most firmware versions. You will need:</p>
 
     <ul>
-    <li>A console with a firmware version from 9.0.0 through 11.3.0.</li>
+    <li>A console with a firmware version from 9.0.0 through 11.3.0 (or 11.4.0 if using a New 3DS).</li>
     <li>For other versions, refer to <a class="md-body-2" href="https://3ds.guide/" target="_blank" rel="noreferrer">Plailect’s guide</a> for possible solutions.</li>
     </ul>
 
-    <p>Use the <a class="md-body-2" href="https://3ds.guide/homebrew-launcher-(soundhax)" target="_blank" rel="noreferrer">SoundHax section of Plailect’s guide</a> to install homebrew. Once your have access to the Homebrew Launcher using SoundHax, you can move on to the next step of this guide. Alternatively, if you are on 11.2.0 or lower and wish to install CFW to help ensure you retain homebrew access after future updates, proceed with the remaining sections of Plailect's guide and return here afterward.</p>
+    <p>If you are on 11.3.0 or lower, use the <a class="md-body-2" href="https://3ds.guide/homebrew-launcher-(soundhax)" target="_blank" rel="noreferrer">SoundHax section of Plailect’s guide</a> to install homebrew. Once your have access to the Homebrew Launcher using SoundHax, you can move on to the next step of this guide. Alternatively, if you wish to install CFW to help ensure you retain homebrew access after future updates, proceed with the remaining sections of Plailect's guide and return here afterward.</p>
+	
+	<p>If you are using a New 3DS on 11.4.0, you will not be able to install CFW, but you may be able to gain homebrew access by using one of the following exploits if you have the required game:</p>
+	
+	<table>
+		<tr>
+			<th>Exploit</th><th>Required Game</th>
+		</tr>
+		<tr>
+			<td><a class="md-body-2" href="https://mrnbayoh.github.io/doodlebomb/" target="_blank" rel="noreferrer">doodlebomb</a></td><td>Swapdoodle (free on Nintendo eShop)</td>
+		</tr>
+		<tr>
+			<td><a class="md-body-2" href="https://smealum.github.io/ninjhax2/" target="_blank" rel="noreferrer">ninjhax</a></td><td>Cubic Ninja</td>
+		</tr>
+		<tr>
+			<td><a class="md-body-2" href="https://plutooo.github.io/freakyhax/" target="_blank" rel="noreferrer">freakyhax</a></td><td>Freakyforms Deluxe</td>
+		</tr>
+	</table>
+	
+	<p>As of this writing on 2017/04/19, homebrew is not useable on old 3DS consoles running 11.4.0.</p>
 
     <h2 class="md-headline">JKSM</h2>
 
@@ -25,7 +44,7 @@
     <li>If you have a CFW, you can install the CIA with <a class="md-body-2" href="https://github.com/Steveice10/FBI/releases" target="_blank" rel="noreferrer">FBI</a>.</li>
     </ul>
 
-    <p>Run JKSM. Pick <code>Cartridge</code> or <code>SD/CIA</code> depending on your game version, select the game, then export the save. Type in a name for the save, and validate. The file can be found in <code>\JSKV\Saves[game][name]</code>.</p>
+    <p>Run JKSM. Pick <code>Cartridge</code> or <code>SD/CIA</code> depending on your game version, select the game, then export the save. Type in a name for the save, and validate. The file can be found in <code>\JSKV\Saves\[game]\[name]</code>.</p>
 
     <p>If you have multiple saves backed up via JKSM for the same game, you need to be careful during the export process as the <code>New</code> option is not at the top by default. Pressing <code>A</code> one too many times could potentially overwrite a different save.</p>
 

--- a/client/static/how-to-pk7-4-tea.html
+++ b/client/static/how-to-pk7-4-tea.html
@@ -9,7 +9,7 @@
     <p>Unlike homebrew, a slightly older firmware version is required for CFW access. You will need:</p>
 
     <ul>
-    <li>A console with a firmware version from 9.0.0 through 11.2.0.</li>
+    <li>A console with a firmware version from 9.0.0 through 11.3.0.</li>
     <li>For other versions, refer to <a class="md-body-2" href="https://3ds.guide/" target="_blank" rel="noreferrer">Plailect's guide</a> for possible solutions.</li>
     <li>/u/Cu3PO42's <a class="md-body-2" href="https://github.com/Cu3PO42/KeySAVe/releases" target="_blank" rel="noreferrer">KeySAVe</a>.</li>
     <li>NTR CFW, installed in the next section.</li>


### PR DESCRIPTION
* Included mention of doodlehax for N3DS users on 11.4
* Updated CFW requirements to note that it is now available for 11.3
* Removed mentions of OoT3D as we don't currently discuss secondary exploits in our documentation