### PR TITLE
Box Size Fix for TID Clipping Caused by long OT

### DIFF
--- a/client/styles/importer.less
+++ b/client/styles/importer.less
@@ -298,7 +298,7 @@ md-card.box-card md-card-content {
 
 @media (min-width: 600px) {
   .pokemon-card-mini {
-    width: 166px;
+    width: 180px;
     height: 220px;
   }
 


### PR DESCRIPTION
I simply increased the width parameters of the pokemon card box.

Before: https://i.imgur.com/aebW5yO.png?1
After: https://i.imgur.com/bGRpKeV.png?1

I'm thinking it should maybe be changed to 200px (incase some crazy long event OT comes out?), but after some testing it looks like 180px will work universally. Note: at 200px width, the rows fit 6 pokemon cards-- this feels more natural w/ 6 cards per row as it mimics the in-game PC layout.