### PR TITLE
Removed whitespace when collapsing columns for mobile/smaller devices

### DIFF
--- a/client/pokemon/pokemon-full.view.html
+++ b/client/pokemon/pokemon-full.view.html
@@ -59,8 +59,8 @@
   <md-tabs md-border-bottom ng-init="pokemon.fetch()" md-dynamic-height>
     <md-tab label="Main Summary">
       <md-tab-body>
-        <div layout="row" layout-xs="column" layout-wrap>
-          <div layout-gt-xs="column">
+        <div class="fake-masonry-container">
+          <div class="fake-masonry-column">
             <md-card class="summary" style="height: 222px;" ng-show="pokemon.hasFullData">
               <md-card-content>
                 <div layout="row" layout-align="none center">
@@ -164,7 +164,7 @@
             </md-card>
           </div>
 
-          <div layout-gt-xs="column">
+          <div class="fake-masonry-column">
             <md-card class="summary" ng-show="pokemon.hasFullData">
               <md-card-header><span class="card-headline">Stats</span></md-card-header>
               <md-card-content>
@@ -224,7 +224,7 @@
             </md-card>
           </div>
 
-          <div layout-gt-xs="column">
+          <div class="fake-masonry-column">
             <md-card class="summary" ng-show="pokemon.hasFullData">
               <md-card-header><span class="card-headline">Encounter Info</span></md-card-header>
               <md-card-content>
@@ -264,8 +264,8 @@
     </md-tab>
     <md-tab label="Other Info">
       <md-tab-body>
-        <div layout="row" layout-xs="column" layout-wrap>
-          <div layout-gt-xs="column">
+        <div class="fake-masonry-container">
+          <div class="fake-masonry-column">
 
             <md-card class="summary" ng-show="pokemon.hasFullData">
               <md-card-header><span class="card-headline">Contest Info</span></md-card-header>
@@ -296,7 +296,7 @@
             </md-card>
           </div>
 
-          <div layout-gt-xs="column">
+          <div class="fake-masonry-column">
           <md-card class="summary" ng-show="pokemon.hasFullData">
             <md-card-header><span class="card-headline">Memories</span></md-card-header>
             <md-card-content>
@@ -368,7 +368,7 @@
           </md-card>
           </div>
 
-          <div layout-gt-xs="column">
+          <div class="fake-masonry-column">
             <md-card class="summary" ng-show="pokemon.hasFullData">
               <md-card-header><span class="card-headline">Super Training</span></md-card-header>
               <md-card-content>

--- a/client/styles/importer.less
+++ b/client/styles/importer.less
@@ -666,3 +666,50 @@ span[class^='gender-'] {
 .dragover {
     border: 5px dashed rgb(2,119,189);
 }
+
+/*******************************
+ * Fake Masonry Effect For Pokemon View
+ *******************************/
+
+.fake-masonry-container {
+  display: grid;
+  grid-template-columns: repeat(3, 360px);
+  grid-column-gap: 0;
+  grid-row-gap: 0;
+}
+
+@media (max-width: 1079.98px) and (min-width: 720px) {
+  // columns are 360px * 3
+  .fake-masonry-column:nth-child(1) {
+    grid-column-start: 1;
+    grid-column-end: 2;
+    grid-row-start: 1;
+    grid-row-end: 2;
+
+  }
+
+  .fake-masonry-column:nth-child(3) {
+    margin-top: -8px; // close gap between columns caused by cards
+    grid-column-start: 1;
+    grid-column-end: 2;
+    grid-row-start: 2;
+    grid-row-end: 3;
+  }
+
+  .fake-masonry-column:nth-child(2) {
+    grid-column-start: 2;
+    grid-column-end: 3;
+    grid-row-start: 1;
+    grid-row-end: 4;
+  }
+}
+
+@media (max-width: 719.98px) {
+  .fake-masonry-container {
+    grid-template-columns: 1fr;
+  }
+
+  .fake-masonry-column + .fake-masonry-column {
+    margin-top: -8px;
+  }
+}


### PR DESCRIPTION
This PR fixes issue #759
The idea behind this is so use a similar effect like the masonry one. It is not exactly the same effect, that's why the classes are called .fake-masonry-*.

Unfortunately the linter doesn't pass, because the master branch is not clean. I avoided to touch files which don't belong to this issue.

Wide viewport: 
![image](https://user-images.githubusercontent.com/25096024/116785082-f5780800-aa97-11eb-9f9a-0dacbb86bde9.png)

2-Column-View: 
![image](https://user-images.githubusercontent.com/25096024/116785101-07f24180-aa98-11eb-9ad1-ebf4bc21265a.png)

Single-Column-View
![image](https://user-images.githubusercontent.com/25096024/116785117-26583d00-aa98-11eb-8464-d81f44f1c3da.png)

